### PR TITLE
Expand on the original settings commit to expose dashboard categories

### DIFF
--- a/res/drawable/dashboard_background_exposed.xml
+++ b/res/drawable/dashboard_background_exposed.xml
@@ -1,12 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2015 Layers Project
 
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape  android:shape="rectangle">
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
 
-            <solid android:color="@color/exposed_bg_dark" />
+          http://www.apache.org/licenses/LICENSE-2.0
 
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="@color/theme_accent">
+    <item android:top="0dip" android:bottom="0dip">
+        <shape>
+            <solid android:color="@color/dashboard_category_background_color" />
+            <stroke android:width="@dimen/dashboard_border_width" android:color="@color/dashboard_border_color" />
+            <corners android:bottomLeftRadius="@dimen/dashboard_radius_bottom_left"
+                     android:bottomRightRadius="@dimen/dashboard_radius_bottom_right"
+                     android:topLeftRadius="@dimen/dashboard_radius_top_left"
+                     android:topRightRadius="@dimen/dashboard_radius_top_right" />
         </shape>
     </item>
-</layer-list>
 
+</ripple>

--- a/res/values/custom_colors.xml
+++ b/res/values/custom_colors.xml
@@ -28,6 +28,7 @@
     <color name="text_color_white">@color/exposed_primary_text_dark</color>
     <!-- Dashboard background color -->
     <color name="dashboard_category_background_color">@color/exposed_bg_dark</color>
+    <color name="dashboard_border_color">@color/exposed_bg_dark</color>
     <!-- Data usage chart color -->
     <color name="data_usage_stroke_color">#00000000</color>
     <color name="data_usage_fill_color">@color/exposed_datachartfillcolor</color>

--- a/res/values/custom_dimens.xml
+++ b/res/values/custom_dimens.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2009 The Android Open Source Project
+     Copyright (C) 2015 Layers Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- Category border width -->
+    <dimen name="dashboard_border_width">0dip</dimen>
+
+    <!-- Individual corner control -->
+    <dimen name="dashboard_radius_bottom_left">0dip</dimen>
+    <dimen name="dashboard_radius_bottom_right">0dip</dimen>
+    <dimen name="dashboard_radius_top_left">0dip</dimen>
+    <dimen name="dashboard_radius_top_right">0dip</dimen>
+
+</resources>


### PR DESCRIPTION
Original commit by Branden M here https://github.com/SafeHouseLP/platform_packages_apps_settings/commit/d82bc73e79cba7d04def1571656d42e972d9aa27

This will allow each category corner to be controled for radius and an adjustable border color / width to be added
PS-1 Me
Added an adjustable border width and color
    dimens.xml = <dimen name="dashboard_border_width">0dip</dimen>
    Colors.xml = <color name="dashboard_border_color">@color/exposed_bg_dark</color>

PS-2 Me
Added adjustable corner radius control

PS-3 Branden M
Broke corner control down to individual corners

```
dimens.xml = <dimen name="dashboard_radius_bottom_left">0dip</dimen>
             <dimen name="dashboard_radius_bottom_right">0dip</dimen>
             <dimen name="dashboard_radius_top_left">0dip</dimen>
             <dimen name="dashboard_radius_top_right">0dip</dimen>
```
